### PR TITLE
SDL2::PixelFormat#{get_rgb,get_rgba}: Don't ignore results.

### DIFF
--- a/lib/sdl2/pixel_format.rb
+++ b/lib/sdl2/pixel_format.rb
@@ -101,20 +101,18 @@ module SDL2
     
     # Get the RGB components (array) from a pixel value
     def get_rgb(pixel)
-      ptr = Hash.new(){TypedPointer::UInt8.new}
-      SDL2.get_rgb(pixel, self, ptr[:r], ptr[:g], ptr[:b])
-      result = []
-      ptr.each_value{|s|result << s[:value]}
+      ptr = 3.times.map{TypedPointer::UInt8.new}
+      SDL2.get_rgb(pixel, self, *ptr)
+      result = ptr.map{|s|s[:value]}
       ptr.each(&:free)
       return result
     end
 
     # Get the RGBA components (array) from a pixel value
     def get_rgba(pixel)
-      ptr = Hash.new(){TypedPointer::UInt8.new}
-      SDL2.get_rgba(pixel, self, ptr[:r], ptr[:g], ptr[:b], ptr[:a])
-      result = []
-      ptr.each_value{|s|result << s[:value]}
+      ptr = 4.times.map{TypedPointer::UInt8.new}
+      SDL2.get_rgba(pixel, self, *ptr)
+      result = ptr.map{|s|s[:value]}
       ptr.each(&:free)
       return result
     end


### PR DESCRIPTION
[`Hash#default_proc`][Hash-default_proc] wants a proc that assigns the new item into the hash.
Just use an array instead, we know how many there are and names don't
matter.

Note that I wasn't able to run the specs (they crash locally on upstream `master`); probably some environment thing.  Also, it would be nice to get `Gemfile.lock` checked in; `approvals` 0.0.21 didn't work for me (but 0.0.20 wasn't obviously broken).

Thanks for the gem :)

[Hash-default_proc]: http://www.rubydoc.info/stdlib/core/Hash%3Ainitialize